### PR TITLE
Remove maximum pins on lalsuite components

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - em_bright_categorize = ligo.em_bright.categorize:main
@@ -36,8 +36,8 @@ requirements:
     - pandas >=1.0,<2.0
     - python >=3.8,<4.0
     - python-htcondor >=9.0.6
-    - python-lal >=7.1.3,<8.0.0
-    - python-lalsimulation >=3.0.0,<4.0.0
+    - python-lal >=7.1.3
+    - python-lalsimulation >=3.0.0
     - scikit-learn >=1.1.0,<2.0.0
 
 test:


### PR DESCRIPTION
This PR removes the maximum pins on the LALSuite components.

New lalsuite subpackage major versions don't correspond to lalsuite major versions, so mapping from the upstream lalsuite ~7 requirement is hard, so the easiest thing to do is to just unpin everything and rely on the test suite to catch compatibility issues.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
